### PR TITLE
Help doesn't list "deploy" commands

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,6 @@
+fs = require 'fs'
+path = require 'path'
+
+module.exports = (robot) ->
+  scriptsPath = path.resolve(__dirname, 'src')
+  robot.loadFile(scriptsPath, 'index.coffee')

--- a/package.json
+++ b/package.json
@@ -22,6 +22,5 @@
     "pulsar-rest-api-client-node": "^0.4.2",
     "underscore": "^1.5.2",
     "hubot-auth": "^1.2.0"
-  },
-  "main": "./src/index"
+  }
 }

--- a/src/deploy.coffee
+++ b/src/deploy.coffee
@@ -1,12 +1,3 @@
-# Description:
-#   Deploy applications with pulsar
-#
-# Commands:
-#   hubot deploy pending <application> <environment> - Show pending changes
-#   hubot deploy <application> <environment> - Deploy application
-
-_ = require('underscore')
-
 DeploymentMonitor = require('./deployment/monitor')
 deploymentMonitor = new DeploymentMonitor()
 

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,3 +1,12 @@
+# Description:
+#   Deploy applications with pulsar
+#
+# Commands:
+#   hubot deploy pending <application> <environment> - Show pending changes
+#   hubot deploy <application> <environment> - Deploy application
+#   hubot confirm deploy - Confirms the deploy that was requested by `deploy` command. Actual only if there was the requested deploy.
+#   hubot cancel deploy - Cancels the deploy that was requested by `deploy` command. Actual only if there was the requested deploy.
+
 PulsarApiClient = require('pulsar-rest-api-client-node')
 Config = require('./config')
 


### PR DESCRIPTION
When saying "help" hubot lists all available commands. I guess it reads it from the script's headers?

Seems it doesn't work for "hubot-pulsar" commands:
> help
```
Cargobot <user> doesn't have <role> role - Removes a role from a user
Cargobot <user> has <role> role - Assigns a role to a user
Cargobot help - Displays all of the help commands that Hubot knows about.
Cargobot help <query> - Displays all help commands that match <query>.
Cargobot what roles do I have - Find out what roles you have
Cargobot what roles does <user> have - Find out what roles a user has
Cargobot what should i eat for lunch? - Display random lunch option
Cargobot who has <role> role - Find out who has the given role
```

Can you check why?