### PR TITLE
deploy-mutex.js: 'split' of undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-pulsar",
   "description": "Hubot script to deploy via Pulsar REST API",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "author": "Cargomedia",
   "license": "MIT",
   "keywords": [

--- a/src/deploy-mutex.js
+++ b/src/deploy-mutex.js
@@ -90,9 +90,12 @@ DeployMutex.prototype.removeJob = function() {
  * @returns {string}
  */
 DeployMutex._getLastText = function(text) {
+  if (!text) {
+    return '';
+  }
   var textLines = text.split(/\r?\n/);
   var n = textLines.length - 1;
-  while (!textLines[n].trim() && n > 0) {
+  while (n > 0 && !textLines[n].trim()) {
     n--;
   }
   return textLines[n];


### PR DESCRIPTION
Happens sometimes:
```
Getting changes…
Hubot> Pending changes for denkmal production:



Say "CONFIRM DEPLOY" or "CANCEL DEPLOY".
[Thu Apr 14 2016 16:30:51 GMT+0200 (CEST)] ERROR TypeError: Cannot read property 'split' of undefined
  at Function.DeployMutex._getLastText (/Users/reto/Projects/hubot-pulsar/src/deploy-mutex.js:93:23)
  at JobMonitor.<anonymous> (/Users/reto/Projects/hubot-pulsar/src/deploy-mutex.js:39:72)
  at emitOne (events.js:90:13)
  at JobMonitor.emit (events.js:182:7)
  at JobMonitor.<anonymous> (/Users/reto/Projects/hubot-pulsar/src/job-monitor.js:41:10)
  at tryOnTimeout (timers.js:224:11)
  at Timer.listOnTimeout (timers.js:198:5)
```