### PR TITLE
Handle "cancel deploy" during release

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "hubot-auth": "^1.2.0"
   },
   "devDependencies": {
+    "bluebird": "^3.4.6",
     "chai": "^3.5.0",
     "coffee-script": "^1.9.0",
     "mocha": "^2.4.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "$(npm bin)/mocha"
   },
   "dependencies": {
-    "pulsar-rest-api-client-node": "^0.4",
+    "pulsar-rest-api-client-node": "^0.5",
     "pulsar-rest-api": "^0.5.2",
     "underscore": "^1.8.2",
     "hubot-auth": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-pulsar",
   "description": "Hubot script to deploy via Pulsar REST API",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "author": "Cargomedia",
   "license": "MIT",
   "keywords": [

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -107,8 +107,14 @@ module.exports = function(robot) {
     }
     var job = deployMutex.getJobWithTask('deploy');
     if (job) {
-      chat.send('Deployment cancelled.');
-      deployMutex.removeJob();
+      pulsarApi.killJob(job)
+        .then(function() {
+          chat.send('Deployment cancelled.');
+          deployMutex.removeJob();
+        })
+        .catch(function() {
+          chat.send('Deployment cancellation failed.');
+        });
     } else {
       chat.send('No deploy job to cancel');
     }

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -1,6 +1,7 @@
 var assert = require('chai').assert;
 var sinon = require('sinon');
 var _ = require('underscore');
+var Promise = require('bluebird');
 require('coffee-script/register');
 var humock = require('mock-hubot');
 
@@ -16,7 +17,8 @@ describe('Deploy script tests', function() {
   before(function() {
     global.pulsarApi = {
       createJob: _.noop,
-      runJob: _.noop
+      runJob: _.noop,
+      killJob: _.noop
     };
   });
 
@@ -95,6 +97,16 @@ describe('Deploy script tests', function() {
     });
 
     context('deploy', function() {
+      beforeEach(function() {
+        sinon.stub(pulsarApi, 'killJob', function() {
+          return Promise.delay(200);
+        });
+      });
+
+      afterEach(function() {
+        global.pulsarApi.killJob.restore();
+      });
+
       it('confirms', function(done) {
         askHubot('hubot deploy app env')
           .response(1, function(response) {

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -51,9 +51,9 @@ describe('Deploy script tests', function() {
 
     beforeEach(function() {
       sinon.stub(pulsarApi, 'runJob', function(job) {
-        _.delay(function() {
+        return Promise.delay(100).then(function() {
           job.emit('success');
-        }, 200);
+        });
       });
     });
 


### PR DESCRIPTION
When sending "cancel deploy" during a running release we should:
- Stop/kill the running release
- Accept new deployments

Currently the script goes into a weird state, and the deployment continues.

cc @cargomedia/devops 