### PR TITLE
"confirm deploy" without an active job leads to "confirmed" state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-pulsar",
   "description": "Hubot script to deploy via Pulsar REST API",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "Cargomedia",
   "license": "MIT",
   "keywords": [

--- a/src/deploy.js
+++ b/src/deploy.js
@@ -92,9 +92,9 @@ module.exports = function(robot) {
       chat.send('Job is already confirmed');
       return;
     }
-    deployMutex.setConfirmed();
     var job = deployMutex.getJobWithTask('deploy');
     if (job) {
+      deployMutex.setConfirmed();
       pulsarApi.runJob(job);
       chat.send('Deployment confirmed.');
     } else {


### PR DESCRIPTION
When sending "confirm deploy" but there is no active job then the bot responds with "No deploy job to confirm".

Still internally he keeps the state like if a job was confirmed (deploy mutex).
New jobs cannot be confirmed there fore ("Job is already confirmed").

@vogdb could you look into this?